### PR TITLE
deploy to server root. fixes #8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN chmod 0644 /etc/cron.d/opengrok-cron
 #ENVIRONMENT VARIABLES CONFIGURATION
 ENV SRC_ROOT /src
 ENV DATA_ROOT /data
+ENV OPENGROK_WEBAPP_CONTEXT /
 ENV OPENGROK_TOMCAT_BASE /usr/local/tomcat
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -39,7 +40,8 @@ WORKDIR $CATALINA_HOME
 
 # custom deployment to / with redirect from /source
 RUN rm -rf /usr/local/tomcat/webapps/* && \
-    cp "/opengrok/lib/source.war" "/usr/local/tomcat/webapps/ROOT.war" && \
+    /opengrok/bin/OpenGrok deploy && \
+    mv "/usr/local/tomcat/webapps/source.war" "/usr/local/tomcat/webapps/ROOT.war" && \
     mkdir "/usr/local/tomcat/webapps/source" && \
     echo '<% response.sendRedirect("/"); %>' > "/usr/local/tomcat/webapps/source/index.jsp"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,12 @@ ENV JRE_HOME /usr
 ENV CLASSPATH /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
 
 WORKDIR $CATALINA_HOME
-RUN /opengrok/bin/OpenGrok deploy
+
+# custom deployment to / with redirect from /source
+RUN rm -rf /usr/local/tomcat/webapps/* && \
+    cp "/opengrok/lib/source.war" "/usr/local/tomcat/webapps/ROOT.war" && \
+    mkdir "/usr/local/tomcat/webapps/source" && \
+    echo '<% response.sendRedirect("/"); %>' > "/usr/local/tomcat/webapps/source/index.jsp"
 
 EXPOSE 8080
 EXPOSE 22

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ First inspect the docker container so you can find the address to connect, then 
 * pass:root
 
 ## Default URL:
-localhost:8080/source
+localhost:8080/
 
 Enjoy.


### PR DESCRIPTION
This deploys OpenGrok as the default web app in tomcat. All tomcat default apps, docs and examples have been removed from the webapps dir.
A redirect from /source has been added for backward compatibility.