### PR TITLE
Remove SSH daemon and explain how to use docker exec instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,7 @@ RUN tar -zxvf /opengrok.tar.gz && mv opengrok-* /opengrok && \
     ln -s /src /var/opengrok/src
 
 #INSTALLING DEPENDENCIES
-#SSH configuration
-RUN apt-get update && apt-get install -y git subversion mercurial unzip openssh-server inotify-tools python3 python3-pip && \
-    mkdir /var/run/sshd && \
-    echo 'root:root' |chpasswd && \
-    sed -ri 's/[ #]*PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config && \
-    sed -ri 's/[ #]*UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
+RUN apt-get update && apt-get install -y git subversion mercurial unzip inotify-tools python3 python3-pip && \
     python3 -m pip install /opengrok/tools/opengrok-tools*
 # compile and install universal-ctags
 RUN apt-get install -y pkg-config autoconf build-essential && git clone https://github.com/universal-ctags/ctags /root/ctags && \
@@ -63,5 +58,4 @@ RUN chmod -R +x /scripts
 # run
 WORKDIR $CATALINA_HOME
 EXPOSE 8080
-EXPOSE 22
 CMD ["/scripts/start.sh"]

--- a/README.md
+++ b/README.md
@@ -11,22 +11,21 @@ The container is available from DockerHub at https://hub.docker.com/r/opengrok/d
 
 ## Additional info about the container:
 
-* SSH with root access
 * Tomcat 9
 * JRE 8 (Required for Opengrok 1.0+);
 * Configurable reindexing (default every 10 min);
 
 ## How to run:
 
-The container exports ports 8080 for OpenGrok and 22 for SSH.
+The container exports ports 8080 for OpenGrok.
 
-    docker run -d -v <path/to/your/src>:/src -p 8080:8080 -p 2222:22 opengrok/docker:latest
+    docker run -d -v <path/to/your/src>:/src -p 8080:8080 opengrok/docker:latest
 
 The volume mounted to `/src` should contain the projects you want to make searchable (in sub directories). You can use common revision control checkouts (git, svn, etc...) and OpenGrok will make history and blame information available.
 
 By default, the index will be rebuild every ten minutes. You can adjust this time (in Minutes) by passing the `REINDEX` environment variable:
 
-    docker run -d -e REINDEX=30 -v <path/to/your/src>:/src -p 8080:8080 -p 2222:22 opengrok/docker:latest
+    docker run -d -e REINDEX=30 -v <path/to/your/src>:/src -p 8080:8080 opengrok/docker:latest
 
 Setting `REINDEX` to `0` will disable automatic indexing. You can manually trigger an reindex using docker exec:
 
@@ -40,13 +39,12 @@ http://localhost:8080/
 
 Please note: on first startup, the web interface will display an error until the indexing has been completed. Give it a few minutes and reload.
 
-## SSH:
+## Inspecting the container
 
-With the command above you can connect to localhost on port 2222 per SSH to inspect the container.
+You can get inside a container using the [command below](https://docs.docker.com/engine/reference/commandline/exec/):
 
-Use the following credentials to do so:
-
-* user: `root`
-* pass: `root`
+```
+docker exec -it <container> bash
+```
 
 Enjoy.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -32,5 +32,4 @@ start_opengrok(){
 
 #START ALL NECESSARY SERVICES.
 start_opengrok &
-catalina.sh run &
-/usr/sbin/sshd -D
+catalina.sh run


### PR DESCRIPTION
No need to expose SSH with insecure credentials when one can use standard Docker commands for container administration.