### PR TITLE
Remove data and src symlinks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,9 @@ MAINTAINER OpenGrok developers "opengrok-dev@yahoogroups.com"
 
 #PREPARING OPENGROK BINARIES AND FOLDERS
 COPY --from=fetcher opengrok.tar.gz /opengrok.tar.gz
-RUN mkdir /opengrok && tar -zxvf /opengrok.tar.gz -C /opengrok --strip-components 1 && rm -f /opengrok.tar.gz && \
-    mkdir /src && \
-    mkdir /data && \
-    mkdir -p /var/opengrok/etc/ && \
-    ln -s /data /var/opengrok && \
-    ln -s /src /var/opengrok/src
+RUN mkdir -p /opengrok /var/opengrok/etc /opengrok/data /opengrok/src && \
+    tar -zxvf /opengrok.tar.gz -C /opengrok --strip-components 1 && \
+    rm -f /opengrok.tar.gz
 
 #INSTALLING DEPENDENCIES
 RUN apt-get update && apt-get install -y git subversion mercurial unzip inotify-tools python3 python3-pip && \
@@ -28,8 +25,8 @@ RUN apt-get install -y pkg-config autoconf build-essential && git clone https://
     cd /root && rm -rf /root/ctags
 
 #ENVIRONMENT VARIABLES CONFIGURATION
-ENV SRC_ROOT /src
-ENV DATA_ROOT /data
+ENV SRC_ROOT /opengrok/src
+ENV DATA_ROOT /opengrok/data
 ENV OPENGROK_WEBAPP_CONTEXT /
 ENV OPENGROK_TOMCAT_BASE /usr/local/tomcat
 ENV CATALINA_HOME /usr/local/tomcat

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ The indexer is set so that it does not log into files.
 
 The container exports ports 8080 for OpenGrok.
 
-    docker run -d -v <path/to/your/src>:/src -p 8080:8080 opengrok/docker:latest
+    docker run -d -v <path/to/your/src>:/opengrok/src -p 8080:8080 opengrok/docker:latest
 
-The volume mounted to `/src` should contain the projects you want to make searchable (in sub directories). You can use common revision control checkouts (git, svn, etc...) and OpenGrok will make history and blame information available.
+The volume mounted to `/opengrok/src` should contain the projects you want to make searchable (in sub directories). You can use common revision control checkouts (git, svn, etc...) and OpenGrok will make history and blame information available.
 
 By default, the index will be rebuild every ten minutes. You can adjust this time (in Minutes) by passing the `REINDEX` environment variable:
 
-    docker run -d -e REINDEX=30 -v <path/to/your/src>:/src -p 8080:8080 opengrok/docker:latest
+    docker run -d -e REINDEX=30 -v <path/to/your/src>:/opengrok/src -p 8080:8080 opengrok/docker:latest
 
 Setting `REINDEX` to `0` will disable automatic indexing. You can manually trigger an reindex using docker exec:
 

--- a/scripts/index.sh
+++ b/scripts/index.sh
@@ -11,7 +11,10 @@ touch $LOCKFILE
 date +"%F %T Indexing starting"
 opengrok-indexer \
     -a /opengrok/lib/opengrok.jar -- \
-    -s /src -d /data -H -P -S -G $INDEXER_OPT \
+    -s /opengrok/src \
+    -d /opengrok/data \
+    -H -P -S \
+    -G $INDEXER_OPT \
     --leadingWildCards on \
     -W /var/opengrok/etc/configuration.xml \
     -U http://localhost:8080 "$@"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,9 +13,9 @@ indexer(){
 	done
 	date +"%F %T Startup finished"
 
-	if [[ ! -d /data/index ]]; then
+	if [[ ! -d /opengrok/data/index ]]; then
 		# Populate the webapp with bare configuration.
-		BODY_INCLUDE_FILE="/data/body_include"
+		BODY_INCLUDE_FILE="/opengrok/data/body_include"
 		if [[ -f $BODY_INCLUDE_FILE ]]; then
 			mv "$BODY_INCLUDE_FILE" "$BODY_INCLUDE_FILE.orig"
 		fi


### PR DESCRIPTION
It makes data and src directories, instead of symlinks.

This fixes a weird issue when the indexed data is mounted outside of the Docker container.

Related to #27. 