### PR TITLE
Add INDEXER_OPT to pass extra options to opengrok-indexer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Setting `REINDEX` to `0` will disable automatic indexing. You can manually trigg
 
     docker exec <container> /scripts/index.sh
 
+Setting `INDEXER_OPT` could pass extra options to opengrok-indexer. For example, you can run with:
+
+    docker run -d -e INDEXER_OPT="-i d:vendor" -v <path/to/your/src>:/src -p 8080:8080 opengrok/docker:latest
+
+To remove all the `*/vendor/*` files from the index. You can check the indexer options on
+
+https://github.com/oracle/opengrok/wiki/Python-scripts-transition-guide
+
 ## OpenGrok Web-Interface
 
 The container has OpenGrok as default web app installed (accessible directly from `/`). With the above container setup, you can find it running on

--- a/scripts/index.sh
+++ b/scripts/index.sh
@@ -11,7 +11,7 @@ touch $LOCKFILE
 date +"%F %T Indexing starting"
 opengrok-indexer \
     -a /opengrok/lib/opengrok.jar -- \
-    -s /src -d /data -H -P -S -G \
+    -s /src -d /data -H -P -S -G $INDEXER_OPT \
     -W /var/opengrok/etc/configuration.xml -U http://localhost:8080 "$@"
 rm -f $LOCKFILE
 date +"%F %T Indexing finished"


### PR DESCRIPTION
The new OpenGrok wrapper script needs users to supply indexer options directly, instead of setting the environment variables. This commit added `INDEXER_OPT` environment variable to allow the user add additional indexer options when running the docker. So we can use this variable to add ignore patterns, etc.