### PR TITLE
add repository mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,17 @@ The container is available from DockerHub at https://hub.docker.com/r/opengrok/d
 
 This image is simple wrapper around OpenGrok environment. The indexer and the web container are **not** tuned for large workloads. If you happen to have either large source data (e.g. [AOSP](https://en.wikipedia.org/wiki/Android_Open_Source_Project) or the like) or stable service or both, it is advisable to run the service standalone.
 
-Also, the image is not capable of source data synchronization. This means the inconsistency time window when index is not consistent with source data can be quite large. This can lead to problems. It is recommended to run the indexer (see below on how to do that) immediately after source data is changed.
-
 ## Additional info about the container:
 
 * Tomcat 9
 * JRE 8 (Required for Opengrok 1.0+)
-* Configurable reindexing (default every 10 min)
+* Configurable mirroring/reindexing (default every 10 min)
 
-The indexer is set so that it does not log into files.
+The mirroring step works by going through all projects and attempting to
+synchronize all its repositories (e.g. it will do `git pull` for Git
+repositories).
+
+The indexer/mirroring is set so that it does not log into files.
 
 ## How to run:
 
@@ -33,7 +35,8 @@ The container exports ports 8080 for OpenGrok.
 
 The volume mounted to `/opengrok/src` should contain the projects you want to make searchable (in sub directories). You can use common revision control checkouts (git, svn, etc...) and OpenGrok will make history and blame information available.
 
-By default, the index will be rebuild every ten minutes. You can adjust this time (in Minutes) by passing the `REINDEX` environment variable:
+By default, the index will be rebuild every ten minutes. You can adjust this
+time (in minutes) by passing the `REINDEX` environment variable:
 
     docker run -d -e REINDEX=30 -v <path/to/your/src>:/opengrok/src -p 8080:8080 opengrok/docker:latest
 
@@ -49,17 +52,15 @@ To remove all the `*/vendor/*` files from the index. You can check the indexer o
 
 https://github.com/oracle/opengrok/wiki/Python-scripts-transition-guide
 
+To avoid the mirroring step, set the `NOMIRROR` variable to non-empty value.
+
 ## OpenGrok Web-Interface
 
 The container has OpenGrok as default web app installed (accessible directly from `/`). With the above container setup, you can find it running on
 
 http://localhost:8080/
 
-Please note: on first startup, the web interface will display empty content
-until the indexing has been completed. Give it some time (depending on the
-amount of data indexed - might take many hours for large code bases !) and reload.
-
-The subsequent reindex will be incremental so will take signigicantly less time.
+The first reindex will take some time to finish. Subsequent reindex will be incremental so will take signigicantly less time.
 
 ## Inspecting the container
 

--- a/scripts/index.sh
+++ b/scripts/index.sh
@@ -1,22 +1,31 @@
 #!/bin/bash
 
 LOCKFILE=/var/run/opengrok-indexer
+URI="http://localhost:8080"
 
 if [ -f "$LOCKFILE" ]; then
-    date +"%F %T Indexer still locked, skipping indexing"
-    exit 1
+	date +"%F %T Indexer still locked, skipping indexing"
+	exit 1
 fi
 
 touch $LOCKFILE
+
+if [ -z $NOMIRROR ]; then
+	date +"%F %T Mirroring starting"
+	opengrok-mirror --all --uri "$URI"
+	date +"%F %T Mirroring finished"
+fi
+
 date +"%F %T Indexing starting"
 opengrok-indexer \
     -a /opengrok/lib/opengrok.jar -- \
     -s /opengrok/src \
     -d /opengrok/data \
-    -H -P -S \
-    -G $INDEXER_OPT \
+    -H -P -S -G \
     --leadingWildCards on \
     -W /var/opengrok/etc/configuration.xml \
-    -U http://localhost:8080 "$@"
-rm -f $LOCKFILE
+    -U "$URI" \
+    $INDEXER_OPT "$@"
 date +"%F %T Indexing finished"
+
+rm -f $LOCKFILE

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -27,7 +27,7 @@ indexer(){
 		fi
 
 		# Perform initial indexing.
-		/scripts/index.sh
+		NOMIRROR=1 /scripts/index.sh
 		date +"%F %T Initial reindex finished"
 	fi
 


### PR DESCRIPTION
The mirroring step can only be done after repositories are detected in order to be able to retrieve repository-project mapping using RESTful API, i.e. after initial reindex.

depends on OpenGrok 1.2.7